### PR TITLE
iOS7でロック画面の再生ボタン/停止ボタンが動作しないのを対応

### DIFF
--- a/MusicStoreLite/FNMusicPlayManager.m
+++ b/MusicStoreLite/FNMusicPlayManager.m
@@ -283,6 +283,8 @@ static const NSString *PlayerRateContext;
         
         switch (receivedEvent.subtype) {
                 
+            case UIEventSubtypeRemoteControlPlay:
+            case UIEventSubtypeRemoteControlPause:
             case UIEventSubtypeRemoteControlTogglePlayPause:
                 [self playOrPause];
                 break;


### PR DESCRIPTION
iOS7からロック画面に表示される再生ボタン/停止ボタンを押しても
UIEventSubtypeRemoteControlTogglePlayPauseが発生しないようになっていて、
再生と停止が動作していませんでした。

その代わり、再生させようとした際はUIEventSubtypeRemoteControlPlayイベントが発生し、
停止させようとした際はUIEventSubtypeRemoteControlPauseイベントが発生するようになってました。

また、Appleイヤフォンからの再生/停止操作はトグルボタンだからなのか、
UIEventSubtypeRemoteControlTogglePlayPauseが発生していたのでそれはそのままです。

iOS7の色々な音楽再生アプリで動作しなくなっていて、
理由を調べたかっただけなんですが折角なのでプルリクエストしておきます。
